### PR TITLE
ignore o365_token.txt anywhere in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 workspace.xml
 mrd/ui/img/hostname_qr.png
 mrd/configuration.ini
-mrd/o365_token.txt
+o365_token.txt


### PR DESCRIPTION
To prevent from the mistake, change the .gitignore to ignore o365_token.txt file from anywhere in the repository.